### PR TITLE
Update kubeseal to 0.12.6

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -2,7 +2,7 @@
 # It is queried by the internal Lunar Way tooling so changes to this file will
 # propagate to all Lunar Way developers.
 
-bitnami-labs/sealed-secrets::v0.12.5::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.5/kubeseal-darwin-amd64
+bitnami-labs/sealed-secrets::v0.12.6::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.6/kubeseal-darwin-amd64
 kubernetes/kops::v1.17.1::https://github.com/kubernetes/kops/releases/download/v1.17.1/kops-darwin-amd64
 kubernetes/kubectl::v1.17.9::https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64


### PR DESCRIPTION
Addition of stdin flags along with other minor changes. Nothing we use.

https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v0126

Tested out locally.