### PR TITLE
Upgrade to kops 1.18.2

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -3,7 +3,7 @@
 # propagate to all Lunar Way developers.
 
 bitnami-labs/sealed-secrets::v0.12.6::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.6/kubeseal-darwin-amd64
-kubernetes/kops::v1.17.1::https://github.com/kubernetes/kops/releases/download/v1.17.1/kops-darwin-amd64
+kubernetes/kops::v1.18.2::https://github.com/kubernetes/kops/releases/download/v1.18.2/kops-darwin-amd64
 kubernetes/kubectl::v1.17.9::https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64
 lunarway/release-manager::v0.11.0::https://github.com/lunarway/release-manager/releases/download/v0.11.0/hamctl-darwin-amd64


### PR DESCRIPTION
This upgrades the default version to 1.18.2