### PR TITLE
Upgrade hamctl and artifact to 0.11.2

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -6,6 +6,6 @@ bitnami-labs/sealed-secrets::v0.12.6::https://github.com/bitnami-labs/sealed-sec
 kubernetes/kops::v1.18.2::https://github.com/kubernetes/kops/releases/download/v1.18.2/kops-darwin-amd64
 kubernetes/kubectl::v1.17.9::https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64
-lunarway/release-manager::v0.11.0::https://github.com/lunarway/release-manager/releases/download/v0.11.0/hamctl-darwin-amd64
-lunarway/release-manager-artifact::v0.11.0::https://github.com/lunarway/release-manager/releases/download/v0.11.0/artifact-darwin-amd64
+lunarway/release-manager::v0.11.2::https://github.com/lunarway/release-manager/releases/download/v0.11.2/hamctl-darwin-amd64
+lunarway/release-manager-artifact::v0.11.2::https://github.com/lunarway/release-manager/releases/download/v0.11.2/artifact-darwin-amd64
 lunarway/shuttle::v0.11.0::https://github.com/lunarway/shuttle/releases/download/v0.11.0/shuttle-darwin-amd64


### PR DESCRIPTION
Contains fixes to hamctl describe releases where an error when getting releases was not reported.