### PR TITLE
Upgrade shuttle to 0.13.1

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -8,4 +8,4 @@ kubernetes/kubectl::v1.18.14::https://storage.googleapis.com/kubernetes-release/
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64
 lunarway/release-manager::v0.12.2::https://github.com/lunarway/release-manager/releases/download/v0.12.2/hamctl-darwin-amd64
 lunarway/release-manager-artifact::v0.12.2::https://github.com/lunarway/release-manager/releases/download/v0.12.2/artifact-darwin-amd64
-lunarway/shuttle::v0.12.1::https://github.com/lunarway/shuttle/releases/download/v0.12.1/shuttle-darwin-amd64
+lunarway/shuttle::v0.13.1::https://github.com/lunarway/shuttle/releases/download/v0.13.1/shuttle-darwin-amd64


### PR DESCRIPTION
Contains the new `documentation` command along with strict yaml parsing and other bug fixes.