### PR TITLE
Fix kops version

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -3,7 +3,7 @@
 # propagate to all Lunar Way developers.
 
 bitnami-labs/sealed-secrets::v0.12.6::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.6/kubeseal-darwin-amd64
-kubernetes/kops::v1.20.1::https://github.com/kubernetes/kops/releases/download/v1.18.2/kops-darwin-amd64
+kubernetes/kops::v1.20.1::https://github.com/kubernetes/kops/releases/download/v1.20.1/kops-darwin-amd64
 kubernetes/kubectl::v1.20.7::https://storage.googleapis.com/kubernetes-release/release/v1.18.14/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64
 lunarway/release-manager::v0.12.2::https://github.com/lunarway/release-manager/releases/download/v0.12.2/hamctl-darwin-amd64


### PR DESCRIPTION
Currently only the version name is updated to 1.20.1 but the link still points
to v1.18.2.

This change updates the link. This change will only be reflected with users if
they remove the installed kops version in LW_LOCAL_PATH.