### PR TITLE
Upgrade hamctl to 0.19.0

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -6,6 +6,6 @@ bitnami-labs/sealed-secrets::v0.12.6::https://github.com/bitnami-labs/sealed-sec
 kubernetes/kops::v1.21.4::https://github.com/kubernetes/kops/releases/download/v1.21.4/kops-darwin-amd64
 kubernetes/kubectl::v1.21.11::https://storage.googleapis.com/kubernetes-release/release/v1.21.11/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.4.0::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_darwin_amd64
-lunarway/release-manager::v0.18.0::https://github.com/lunarway/release-manager/releases/download/v0.18.0/hamctl-darwin-amd64
-lunarway/release-manager-artifact::v0.18.0::https://github.com/lunarway/release-manager/releases/download/v0.18.0/artifact-darwin-amd64
+lunarway/release-manager::v0.19.0::https://github.com/lunarway/release-manager/releases/download/v0.19.0/hamctl-darwin-amd64
+lunarway/release-manager-artifact::v0.19.0::https://github.com/lunarway/release-manager/releases/download/v0.19.0/artifact-darwin-amd64
 lunarway/shuttle::v0.14.0::https://github.com/lunarway/shuttle/releases/download/v0.14.0/shuttle-darwin-amd64


### PR DESCRIPTION
The status command now shows all environments instead of only dev and prod. The
release also contains upgrades to dependencies.