### PR TITLE
Update to newest release manager version

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -6,6 +6,6 @@ bitnami-labs/sealed-secrets::v0.16.0::https://github.com/bitnami-labs/sealed-sec
 kubernetes/kops::v1.22.5::https://github.com/kubernetes/kops/releases/download/v1.22.5/kops-darwin-amd64
 kubernetes/kubectl::v1.22.11::https://storage.googleapis.com/kubernetes-release/release/v1.22.11/bin/darwin/amd64/kubectl
 kubernetes-sigs/aws-iam-authenticator::v0.5.3::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.3/aws-iam-authenticator_0.5.3_darwin_amd64
-lunarway/release-manager::v0.22.3::https://github.com/lunarway/release-manager/releases/download/v0.22.3/hamctl-darwin-amd64
-lunarway/release-manager-artifact::v0.22.3::https://github.com/lunarway/release-manager/releases/download/v0.22.3/artifact-darwin-amd64
+lunarway/release-manager::v0.24.0::https://github.com/lunarway/release-manager/releases/download/v0.24.0/hamctl-darwin-amd64
+lunarway/release-manager-artifact::v0.24.0::https://github.com/lunarway/release-manager/releases/download/v0.24.0/artifact-darwin-amd64
 lunarway/shuttle::v0.15.1::https://github.com/lunarway/shuttle/releases/download/v0.15.1/shuttle-darwin-amd64


### PR DESCRIPTION
I've tested this in dev, using my own script, and I am able to release, and rollback.

I'd rather get this out before actually rolling out release-manager itself