### PR TITLE
update shuttle to use 0.17.0

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -8,5 +8,5 @@ kubernetes/kubectl::v1.22.11::https://storage.googleapis.com/kubernetes-release/
 kubernetes-sigs/aws-iam-authenticator::v0.5.3::https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.3/aws-iam-authenticator_0.5.3_darwin_amd64
 lunarway/release-manager::v0.24.0::https://github.com/lunarway/release-manager/releases/download/v0.24.0/hamctl-darwin-amd64
 lunarway/release-manager-artifact::v0.24.0::https://github.com/lunarway/release-manager/releases/download/v0.24.0/artifact-darwin-amd64
-lunarway/shuttle::v0.16.1::https://github.com/lunarway/shuttle/releases/download/v0.16.1/shuttle-darwin-amd64
+lunarway/shuttle::v0.17.0::https://github.com/lunarway/shuttle/releases/download/v0.17.0/shuttle-darwin-amd64
 lunarway/async-schema-tooling::v0.4.0::https://github.com/lunarway/async-schema-tooling/releases/download/v0.4.0/async-schema-tooling-darwin-amd64


### PR DESCRIPTION
Use 0.17.0 to use caching.