### PR TITLE
fix: kubeseal-0.24.4

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -2,7 +2,7 @@
 # It is queried by the internal Lunar Way tooling so changes to this file will
 # propagate to all Lunar Way developers.
 
-bitnami-labs/sealed-secrets::v0.24.4::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.24.4/kubeseal-0.24.3-darwin-amd64.tar.gz
+bitnami-labs/sealed-secrets::v0.24.4::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.24.4/kubeseal-0.24.4-darwin-amd64.tar.gz
 kubernetes/kubectl::v1.26.8::https://storage.googleapis.com/kubernetes-release/release/v1.26.8/bin/darwin/amd64/kubectl
 lunarway/release-manager::v0.27.3::https://github.com/lunarway/release-manager/releases/download/v0.27.3/hamctl-darwin-amd64
 lunarway/release-manager-artifact::v0.26.7::https://github.com/lunarway/release-manager/releases/download/v0.24.0/artifact-darwin-amd64


### PR DESCRIPTION
wrong file name because version mismatch