### PR TITLE
Upgrade kubectl to v1.28.12

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -3,7 +3,7 @@
 # propagate to all Lunar Way developers.
 
 bitnami-labs/sealed-secrets::v0.27.1::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.1/kubeseal-0.27.1-darwin-amd64.tar.gz
-kubernetes/kubectl::v1.26.8::https://storage.googleapis.com/kubernetes-release/release/v1.26.8/bin/darwin/amd64/kubectl
+kubernetes/kubectl::v1.28.12::https://dl.k8s.io/release/v1.28.12/bin/darwin/amd64/kubectl
 lunarway/release-manager::v0.30.1::https://github.com/lunarway/release-manager/releases/download/v0.30.1/hamctl-darwin-amd64
 lunarway/release-manager-artifact::v0.26.7::https://github.com/lunarway/release-manager/releases/download/v0.24.0/artifact-darwin-amd64
 lunarway/shuttle::v0.23.0::https://github.com/lunarway/shuttle/releases/download/v0.23.0/shuttle-darwin-amd64


### PR DESCRIPTION
#119 didn't work because there only was one colon after the version