### PR TITLE
feat: add golang versions to maintain what we should install using go install

### DIFF
--- a/golang_versions
+++ b/golang_versions
@@ -1,0 +1,5 @@
+# This file contains the versions of managed golang releases. 
+# It is used by Lunar tooling to decide which versions of golang binaries should be installed and maintained
+
+# The scheme is <name>::go.lunarway.com/<name>@v0.5.0 as an example
+lunarctl::go.lunarway.com/lunarctl@v0.5.0


### PR DESCRIPTION
This is required for the new lunarctl release which cannot be installed using the regular binary_versions file, as we don't have access to private releases using that approach

Fixes: AURA-2482
