### PR TITLE
Update golang_versions with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>lunarway/renovate-config"
+  "extends": ["local>lunarway/renovate-config"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^golang_versions$"],
+      "matchStrings": [
+        "(?<depName>.*?)::go\\.lunarway\\.com/.+@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
   ]
 }


### PR DESCRIPTION
Currently, the binaries defined in the `golang_binaries` file are not being updated by renovate and they can fall behind.

This change sets up a regex manager that will make sure the binaries are being updated from this point on.