### PR TITLE
Fix renovate regex

### DIFF
--- a/golang_versions
+++ b/golang_versions
@@ -1,5 +1,4 @@
 # This file contains the versions of managed golang releases. 
 # It is used by Lunar tooling to decide which versions of golang binaries should be installed and maintained
 
-# The scheme is <name>::go.lunarway.com/<name>@v0.5.0 as an example
 lunarctl::go.lunarway.com/lunarctl@v0.8.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     {
       "fileMatch": ["^golang_versions$"],
       "matchStrings": [
-        "(?<depName>.*?)::go\\.lunarway\\.com/.+@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+        ".*::(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
Currently, Renovate does not correctly understand how to update golang_version releases due to an error in the regex that incorrectly uses the name by itself as the dependency.

This change fixes the issue by setting the dependency name to be the full string eg. `go.lunarway.com/lunarctl`.