### PR TITLE
Switch to github url instead of go-packages

### DIFF
--- a/golang_versions
+++ b/golang_versions
@@ -1,4 +1,4 @@
 # This file contains the versions of managed golang releases. 
 # It is used by Lunar tooling to decide which versions of golang binaries should be installed and maintained
 
-lunarctl::go.lunarway.com/lunarctl@v0.8.0
+lunarctl::https://github.com/lunarway/lunarctl@v0.8.0


### PR DESCRIPTION
Currently, we get the warning. This change uses the full github url instead of a redirect.

`"warnings":["Failed to look up github-releases package lunarway/release-manager-artifact","Failed to look up github-releases package go.lunarway.com/lunarctl"]`