### PR TITLE
fix: skip github part of golang_versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     {
       "fileMatch": ["^golang_versions$"],
       "matchStrings": [
-        ".*::(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+        ".*::https://github.com/(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
Go install requires the github parts, but renovate doesn't consider it a proper github release
