### PR TITLE
fix: release manager artifacts same versions

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -5,5 +5,5 @@
 bitnami-labs/sealed-secrets::v0.27.1::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.1/kubeseal-0.27.1-darwin-amd64.tar.gz
 kubernetes/kubectl::v1.28.12::https://dl.k8s.io/release/v1.28.12/bin/darwin/amd64/kubectl
 lunarway/release-manager::v0.30.1::https://github.com/lunarway/release-manager/releases/download/v0.30.1/hamctl-darwin-amd64
-lunarway/release-manager-artifact::v0.26.7::https://github.com/lunarway/release-manager/releases/download/v0.24.0/artifact-darwin-amd64
+lunarway/release-manager-artifact::v0.26.7::https://github.com/lunarway/release-manager/releases/download/v0.26.7/artifact-darwin-amd64
 lunarway/shuttle::v0.24.2::https://github.com/lunarway/shuttle/releases/download/v0.24.2/shuttle-darwin-amd64


### PR DESCRIPTION
Theyd gone out of sync, causing issues for renovate

