### PR TITLE
feat: add golang versions instead of github releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
     {
       "fileMatch": ["^golang_versions$"],
       "matchStrings": [
-        ".*::https://github.com/(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+        ".*::(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "golang-version",
       "versioningTemplate": "semver"
     }
   ]


### PR DESCRIPTION
This should mirror how the packages are actually installed, and doesn't require hacks for getting github releases to work

