### PR TITLE
chore: Migrate squad from Aura to Esa

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @lunarway/squad-aura
+* @lunarway/squad-esa
 

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,5 +1,5 @@
 plan: false
 vars:
   service: lw-zsh-versions
-  squad: aura
+  squad: esa
   domain: developer-productivity


### PR DESCRIPTION
This batch change migrates repository ownership from squad-aura to squad-esa.

The following changes have been applied:
- `shuttle.yaml` squad updated to `esa`.
- `CODEOWNERS` updated to reference `@lunarway/squad-esa`.

**Next Steps:**
- Please ensure that the `squad-esa` team has the appropriate permissions on this repository. (Will be done using a script Tinus made)

[_Created by Sourcegraph batch change `jan/aura-to-esa`._](https://lunar.sourcegraph.com/users/jan/batch-changes/aura-to-esa)