### PR TITLE
Migrated rule that only applies to binary versions in here

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,17 @@
       ],
       "datasourceTemplate": "go",
       "versioningTemplate": "semver"
+    },
+    {
+      "description": "regex manager for lw-zsh-versions",
+      "fileMatch": ["binary_versions"],
+      "matchStrings": [
+        "(?<depName>.*?)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::",
+        "(?<depName>.*?)::v?[0-9]+\\.[0-9]+\\.[0-9]+::.*\\/releases\\/download\\/(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)\\/",
+        "(?<depName>.*?)::v?[0-9]+\\.[0-9]+\\.[0-9]+::.*\\/releases\\/download\\/v?[0-9]+\\.[0-9]+\\.[0-9]+\\/.*-(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
This change migrates a regex manager from renovate-config into this repo. This was the only use of it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Renovate regex manager for `binary_versions` using GitHub releases with semver versioning.
> 
> - **Renovate config**:
>   - Add regex manager for `binary_versions` in `renovate.json`:
>     - Matches patterns for `<depName>::<version>::...` and GitHub releases download URLs.
>     - Uses `github-releases` datasource with `semver` versioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab0fa58edd4f39cc79620f857394ee12ef61ab8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->