### PR TITLE
point at kubeseal arm64

### DIFF
--- a/binary_versions
+++ b/binary_versions
@@ -2,7 +2,7 @@
 # It is queried by the internal Lunar Way tooling so changes to this file will
 # propagate to all Lunar Way developers.
 
-bitnami-labs/sealed-secrets::v0.34.0::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.34.0/kubeseal-0.34.0-darwin-amd64.tar.gz
+bitnami-labs/sealed-secrets::v0.34.0::https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.34.0/kubeseal-0.34.0-darwin-arm64.tar.gz
 kubernetes/kubectl::v1.32.10::https://dl.k8s.io/release/v1.32.10/bin/darwin/amd64/kubectl
 lunarway/release-manager::v0.34.0::https://github.com/lunarway/release-manager/releases/download/v0.34.0/hamctl-darwin-amd64
 lunarway/release-manager-artifact::v0.26.7::https://github.com/lunarway/release-manager/releases/download/v0.26.7/artifact-darwin-amd64


### PR DESCRIPTION
v0.34.0 of kubeseal doesn't work on Apple silicon chips. Pointing at arm64 as default instead. I also made some checks in lw-zsh in this regard, if you are on linux/wsl. 

https://github.com/lunarway/lw-zsh/pull/443

fixes ESA-1460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a5992ffc030ae86ff676c69ce47a9358c23b1afa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->