### PR TITLE
Update lunarctl version from v0.11.3 to v0.11.4

### DIFF
--- a/golang_versions
+++ b/golang_versions
@@ -1,4 +1,4 @@
 # This file contains the versions of managed golang releases. 
 # It is used by Lunar tooling to decide which versions of golang binaries should be installed and maintained
 
-lunarctl::go.lunarway.com/lunarctl@v0.11.3
+lunarctl::go.lunarway.com/lunarctl@v0.11.4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump in a tooling-managed Go binary list; main risk is unforeseen behavioral changes in `lunarctl` v0.11.4 affecting developer/CI workflows.
> 
> **Overview**
> Updates the managed Go tooling versions list to install/maintain `lunarctl` at `v0.11.4` instead of `v0.11.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88196418f95f8f1d52c1c7139e65ffa1228c2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->