### PR TITLE
chore: transfer ownership to squad-dark-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter
 

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,5 +1,5 @@
 plan: false
 vars:
   service: lw-zsh-versions
-  squad: esa
+  squad: dark-matter
   domain: developer-productivity


### PR DESCRIPTION
Updates CODEOWNERS and shuttle.yaml to point to squad-dark-matter.

Part of [DMAT-8](https://linear.app/lunar/issue/DMAT-8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates repository ownership metadata only (no runtime code or behavior changes).
> 
> **Overview**
> Transfers repository ownership/maintainership from **squad-esa** to **squad-dark-matter** by updating `CODEOWNERS` and the `squad` value in `shuttle.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f8fd41c926f24136d4b751769ba2c8a4243b3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->