### PR TITLE
fix(renovate): capture packageName from GitHub URL for release-manager-artifact

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,9 +14,8 @@
       "description": "regex manager for lw-zsh-versions",
       "fileMatch": ["binary_versions"],
       "matchStrings": [
-        "(?<depName>.*?)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::",
-        "(?<depName>.*?)::v?[0-9]+\\.[0-9]+\\.[0-9]+::.*\\/releases\\/download\\/(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)\\/",
-        "(?<depName>.*?)::v?[0-9]+\\.[0-9]+\\.[0-9]+::.*\\/releases\\/download\\/v?[0-9]+\\.[0-9]+\\.[0-9]+\\/.*-(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "(?<depName>[^:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://github\\.com/(?<packageName>[^/]+/[^/]+)/",
+        "(?<depName>[^:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::(?!https://github\\.com)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
## Summary

Renovate was failing to look up `lunarway/release-manager-artifact` in `binary_versions` because there is no GitHub repo with that name — the binary lives in `lunarway/release-manager`.

## Changes

- Replace three `matchStrings` patterns with two cleaner, mutually exclusive ones
- Pattern 1 captures `packageName` from the GitHub URL (`lunarway/release-manager`), allowing Renovate to use the correct repo for lookups while keeping `depName` as `lunarway/release-manager-artifact` for display
- Pattern 2 (negative lookahead `(?!https://github\.com)`) handles non-GitHub URLs like kubectl

## Why

Renovate's `github-releases` datasource uses `depName` as the lookup key unless `packageName` is explicitly provided. Since `lunarway/release-manager-artifact` doesn't exist as a repo, the lookup returned `no-result`. The new patterns extract `packageName` directly from the GitHub URL path, which is the actual repo to query.

The previous three-pattern approach also had a correctness bug: patterns 1 and 3 both matched the same GitHub lines, causing Renovate to create duplicate dependency records. Pattern 4 created a spurious third match for `bitnami-labs/sealed-secrets` with a mismatched version format (`0.34.0` vs `v0.34.0`).

Closes DMAT-305

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Renovate regex configuration changes; no runtime app or auth behavior.
> 
> **Overview**
> **Renovate** `binary_versions` regex manager is simplified from three overlapping patterns to two that don’t double-match the same lines.
> 
> For **GitHub** URLs, the first pattern now pulls **`packageName`** from `github.com/org/repo/` so lookups use the real repo (e.g. `lunarway/release-manager`) while **`depName`** can stay as the display name (e.g. `lunarway/release-manager-artifact`). Non-GitHub entries (e.g. **kubectl**) use a second pattern with a negative lookahead so they still resolve without a GitHub **`packageName`**.
> 
> This fixes failed **`github-releases`** lookups when **`depName`** isn’t a repo name and removes duplicate/spurious dependency entries from the old patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de42a8b7d16ffe21be4485002abf0a0485c8dfcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->