### PR TITLE
fix(renovate): migrate regexManagers to customManagers schema

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,10 @@
       "enabled": false
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["^golang_versions$"],
+      "customType": "regex",
+      "managerFilePatterns": ["/^golang_versions$/"],
       "matchStrings": [
         ".*::(?<depName>.*?)@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
@@ -18,11 +19,12 @@
       "versioningTemplate": "semver"
     },
     {
+      "customType": "regex",
       "description": "regex manager for lw-zsh-versions",
-      "fileMatch": ["binary_versions"],
+      "managerFilePatterns": ["/binary_versions/"],
       "matchStrings": [
-        "(?<depName>[^:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://github\\.com/(?<packageName>[^/]+/[^/]+)/",
-        "(?<depName>[^:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::(?!https://github\\.com)"
+        "(?<depName>[^\\n:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://github\\.com/(?<packageName>[^/]+/[^/]+)/",
+        "(?<depName>[^\\n:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://[^g][^\\n]*"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
## Summary

Migrates `renovate.json` from the deprecated `regexManagers` schema to the current `customManagers` schema required by Renovate v38+.

## Changes

- Renamed `regexManagers` → `customManagers`
- Added `"customType": "regex"` to each manager entry
- Renamed `fileMatch` → `managerFilePatterns` with RE2 `/pattern/` delimiters
- Replaced unsupported negative lookahead `(?!https://github\.com)` with RE2-compatible `https://[^g][^\n]*`
- Fixed `depName` capture group from `[^:]+` to `[^\n:]+` to prevent cross-line contamination

## Why

Renovate's deployment logs reported the config as invalid. The `regexManagers` field was removed in newer Renovate versions. The old `depName` pattern (`[^:]+`) matched newlines, causing cross-line matches that would silently prevent version write-backs for multi-line files.

## Evidence

```
$ npx --package renovate@42 -- renovate-config-validator --strict renovate.json
INFO: Validating renovate.json as global config
INFO: Config validated successfully
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to dependency bot rules; behavior intent is preserved with validator-checked schema, with minor risk if the new non-GitHub URL regex misses an edge-case host.
> 
> **Overview**
> Updates **`renovate.json`** so Renovate v38+ accepts the config: **`regexManagers`** becomes **`customManagers`**, each entry gets **`customType: "regex"`**, and **`fileMatch`** becomes **`managerFilePatterns`** with RE2 **`/pattern/`** syntax.
> 
> For the **`binary_versions`** custom manager, the second **`matchStrings`** rule drops the unsupported negative lookahead and uses **`https://[^g][^\n]*`** so non-GitHub URLs (e.g. **`dl.k8s.io`**) still match. **`depName`** capture changes from **`[^:]+`** to **`[^\n:]+`** so matches stay on one line and version write-backs stay reliable in multi-line files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b969ac5dcec1d5b2f0d7e0ead2f09e3b2d05014. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->