### PR TITLE
chore(renovate): ignore sealed-secrets and kubectl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>lunarway/renovate-config"],
+  "packageRules": [
+    {
+      "description": "sealed-secrets and kubectl are updated via k8s upgrades, not Renovate",
+      "matchDepNames": ["bitnami-labs/sealed-secrets", "kubernetes/kubectl"],
+      "enabled": false
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^golang_versions$"],


### PR DESCRIPTION
## Summary

Add a `packageRules` entry to disable Renovate updates for `bitnami-labs/sealed-secrets` and `kubernetes/kubectl`.

## Changes

- Added `packageRules` with `matchDepNames` targeting both packages and `enabled: false`

## Why

These binaries are tied to the Kubernetes cluster version and the sealed-secrets deployment lifecycle — Renovate PRs for them create noise and could cause version drift from the cluster. They should only be updated when k8s is upgraded or the sealed-secrets deployment is changed.

Closes DMAT-326
