### PR TITLE
fix(renovate): rewrite binary_versions download URL on version bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,20 @@
     },
     {
       "customType": "regex",
-      "description": "regex manager for lw-zsh-versions",
+      "description": "binary_versions entries hosted on github releases",
       "managerFilePatterns": ["/binary_versions/"],
       "matchStrings": [
-        "(?<depName>[^\\n:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://github\\.com/(?<packageName>[^/]+/[^/]+)/",
+        "(?<depName>[^\\n:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://github\\.com/(?<packageName>[^/]+/[^/]+)/releases/download/v?[0-9]+\\.[0-9]+\\.[0-9]+/(?<asset>[^\\n]+)"
+      ],
+      "autoReplaceStringTemplate": "{{{depName}}}::{{{newValue}}}::https://github.com/{{{packageName}}}/releases/download/{{{newValue}}}/{{{asset}}}",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "binary_versions entries hosted outside github releases",
+      "managerFilePatterns": ["/binary_versions/"],
+      "matchStrings": [
         "(?<depName>[^\\n:]+)::(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)::https://[^g][^\\n]*"
       ],
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
## Problem

Renovate PR #190 bumps `lunarway/release-manager` `v0.35.0` → `v0.35.3` in the version field but leaves the download URL pinned at `v0.35.0`:

```
lunarway/release-manager::v0.35.3::https://github.com/lunarway/release-manager/releases/download/v0.35.0/hamctl-darwin-amd64
```

Internal tooling labels the binary `v0.35.3` while actually fetching the `v0.35.0` asset, so the bump never ships the intended release.

**Root cause:** the github-releases custom manager matchString stopped at `…/<packageName>/`. The version embedded in the URL was never part of the match, and Renovate's default replacement only rewrites the captured `currentValue` substring — so the URL is structurally incapable of updating.

## Fix

- Extend the github matchString to consume the full `/releases/download/<version>/<asset>` URL, capturing the asset filename.
- Add an `autoReplaceStringTemplate` that rebuilds the line with `newValue` in **both** the version field and the URL path, so they can never diverge.
- Split the non-github (kubectl) entry into its own manager, since the template applies only to the github release URL shape.

## Verification

Simulated the regex + template against every line in `binary_versions` with a synthetic bump:

- All four github-hosted entries rewrite version **and** URL in sync.
- `packageName` is still captured from the URL, preserving the `release-manager-artifact` datasource lookup added in #185.
- The kubectl line still matches the non-github manager with correct `depName`/`currentValue`.

## Follow-up

The already-open #190 / #191 still contain the broken line. After this merges, those should be closed so Renovate regenerates them against the corrected manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate custom managers; no runtime or deployment behavior.
> 
> **Overview**
> Fixes Renovate bumps for `binary_versions` lines where the **declared version** could advance while the **GitHub release download URL** stayed on the old tag.
> 
> The GitHub-hosted manager now matches the full `…/releases/download/<version>/<asset>` path, captures the asset name, and uses **`autoReplaceStringTemplate`** so `newValue` is written into both the version field and the URL. Non-GitHub URLs (e.g. kubectl) are handled by a **separate** regex manager without that template, since the URL shape differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be3abe5d01d7d3220f354cbd032e5ca0a3f8447. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->